### PR TITLE
週間目標時間と現在の研究時間の差分を表示

### DIFF
--- a/src/app/Http/Controllers/DashboardController.php
+++ b/src/app/Http/Controllers/DashboardController.php
@@ -18,7 +18,7 @@ class DashboardController extends Controller
         $targetTime = TargetTime::where('user_id', $userId)->first();
 
         // 今週の研究時間を取得
-        $weeklyTime = WeeklyTime::where('user_id', $userId)->first()->research_time;
+        $weeklyTime = WeeklyTime::where('user_id', $userId)?->first()?->research_time;
 
         return Inertia::render('Dashboard', compact('targetTime', 'userId', 'weeklyTime'));
     }

--- a/src/app/Http/Controllers/DashboardController.php
+++ b/src/app/Http/Controllers/DashboardController.php
@@ -9,17 +9,24 @@ use Illuminate\Support\Facades\Auth;
 
 class DashboardController extends Controller
 {
-
     public function index()
     {
-        // 今週の合計時間、目標時間、今週の時間を計算するサービスを作ったほうがいいかも
+        // ここはサービスで切り出さないほうがよさげ？
         $userId = Auth::id();
+
         // 今週の目標時間を取得
         $targetTime = TargetTime::where('user_id', $userId)->first();
 
-        // 今週の研究時間を取得
-        $weeklyTime = WeeklyTime::where('user_id', $userId)?->first()?->research_time;
+        // 今週の研究・休憩時間を取得
+        $weeklyResearchTime = WeeklyTime::where('user_id', $userId)?->first()?->research_time;
+        $weeklyRestTime = WeeklyTime::where('user_id', $userId)?->first()?->rest_time;
+        if ($weeklyRestTime < $weeklyResearchTime) {
+            // 休憩時間を抜いた研究時間
+            $weeklyTime = $weeklyResearchTime - $weeklyRestTime;
+        } else {
+            $weeklyTime = 0;
+        }
 
-        return Inertia::render('Dashboard', compact('targetTime', 'userId', 'weeklyTime'));
+        return Inertia::render('Dashboard', compact('targetTime', 'weeklyResearchTime', 'weeklyTime'));
     }
 }

--- a/src/app/Http/Controllers/DashboardController.php
+++ b/src/app/Http/Controllers/DashboardController.php
@@ -3,18 +3,23 @@
 namespace App\Http\Controllers;
 
 use App\Models\TargetTime;
+use App\Models\WeeklyTime;
 use Inertia\Inertia;
 use Illuminate\Support\Facades\Auth;
 
 class DashboardController extends Controller
 {
+
     public function index()
     {
         // 今週の合計時間、目標時間、今週の時間を計算するサービスを作ったほうがいいかも
-        // とりあえずフォームで目標時間を保存してそれを表示するまで
         $userId = Auth::id();
+        // 今週の目標時間を取得
         $targetTime = TargetTime::where('user_id', $userId)->first();
 
-        return Inertia::render('Dashboard', compact('targetTime', 'userId'));
+        // 今週の研究時間を取得
+        $weeklyTime = WeeklyTime::where('user_id', $userId)->first()->research_time;
+
+        return Inertia::render('Dashboard', compact('targetTime', 'userId', 'weeklyTime'));
     }
 }

--- a/src/app/Http/Controllers/ResearchController.php
+++ b/src/app/Http/Controllers/ResearchController.php
@@ -2,20 +2,19 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Research;
-use App\Models\Time;
 use App\Models\User;
+use App\Services\ResearchService;
 use Illuminate\Support\Facades\Auth;
 
 class ResearchController extends Controller
 {
-    private $research;
+    private $researchService;
     /**
-     * @param Time $time
+     * @param ResearchService $researchService
      */
-    public function __construct(Research $research)
+    public function __construct(ResearchService $researchService)
     {
-        $this->research = $research;
+        $this->researchService = $researchService;
     }
 
     /**
@@ -26,7 +25,7 @@ class ResearchController extends Controller
     public function storeStartTime()
     {
         $userId = Auth::id();
-        $result = $this->research->storeTime($userId);
+        $result = $this->researchService->store($userId);
         if ($result) {
             return redirect('dashboard')->with('flash_message', '研究開始時間を打刻しました');
         } else { // 研究開始ボタンを2回連続で押した場合は、すでに開始していることをエラーメッセージで表示
@@ -46,7 +45,7 @@ class ResearchController extends Controller
         if ($user->is_rested) {
             return redirect('dashboard')->with('flash_error_message', '休憩を終了してください');
         }
-        $result = $this->research->updateTime($userId);
+        $result = $this->researchService->update($userId);
         if ($result) {
             return redirect('dashboard')->with('flash_message', '研究終了時間を打刻しました');
         } else { // 研究を開始せずに終了しようとした場合にエラーメッセージを表示

--- a/src/app/Http/Controllers/RestController.php
+++ b/src/app/Http/Controllers/RestController.php
@@ -2,17 +2,17 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Rest;
 use App\Models\User;
+use App\Services\RestService;
 use Illuminate\Support\Facades\Auth;
 
 class RestController extends Controller
 {
-    private $rest;
+    private $restService;
 
-    public function __construct(Rest $rest)
+    public function __construct(RestService $restService)
     {
-        $this->rest = $rest;
+        $this->restService = $restService;
     }
 
     /**
@@ -23,10 +23,10 @@ class RestController extends Controller
     public function storeStartTime()
     {
         $user = User::find(Auth::id());
-        if (is_null($user->currentResearch)) { // 研究を開始せずに休憩を開始しようとした場合
+        if ((!$user->is_started)) { // 研究を開始せずに休憩を開始しようとした場合
             return redirect('dashboard')->with('flash_error_message', '研究を開始してください');
         }
-        $result = $this->rest->storeTime($user->currentResearch->id);
+        $result = $this->restService->store($user->currentResearch->id);
         if ($result) {
             return redirect('dashboard')->with('flash_message', '休憩開始時間を打刻しました');
         } else { // 休憩開始ボタンを2回連続で押した場合
@@ -43,7 +43,7 @@ class RestController extends Controller
         if (is_null($user->currentResearch)) { // 研究を開始せずに休憩を終了しようとした場合
             return redirect('dashboard')->with('flash_error_message', '研究をまだ開始していません');
         }
-        $result = $this->rest->updateTime($user->currentResearch->id);
+        $result = $this->restService->update($user->currentResearch->id);
         if ($result) {
             return redirect('dashboard')->with('flash_message', '休憩終了時間を打刻しました');
         } else { // 休憩をまだ開始していない場合

--- a/src/app/Models/Research.php
+++ b/src/app/Models/Research.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Throwable;
 
 class Research extends Model
@@ -64,7 +65,7 @@ class Research extends Model
             DB::commit();
             return true;
         } catch (Throwable $e) {
-            // ログで出力してあげるようにする
+            Log::debug($e);
             DB::rollBack();
         }
     }
@@ -111,6 +112,7 @@ class Research extends Model
             DB::commit();
             return true;
         } catch (Throwable $e) {
+            Log::debug($e);
             DB::rollBack();
         }
     }

--- a/src/app/Models/Research.php
+++ b/src/app/Models/Research.php
@@ -2,29 +2,14 @@
 
 namespace App\Models;
 
-use App\Repositories\WeeklyTime\WeeklyTimeRepository;
-use App\Services\TimeBasedConversionService;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
-use Throwable;
 
 class Research extends Model
 {
     use HasFactory;
 
     protected $table = 'researches';
-
-    private $timeBasedConversionService;
-    private $weeklyTimeRepository;
-
-    public function __construct(TimeBasedConversionService $timeBasedConversionService, WeeklyTimeRepository $weeklyTimeRepository)
-    {
-        $this->timeBasedConversionService = $timeBasedConversionService;
-        $this->weeklyTimeRepository = $weeklyTimeRepository;
-    }
 
     /**
      * The attributes that are mass assignable.
@@ -40,80 +25,5 @@ class Research extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
-    }
-
-    /**
-     * 開始時間を登録する
-     *
-     * @param integer $userId
-     * @return boolean
-     */
-    public function storeTime(int $userId)
-    {
-        try {
-            DB::beginTransaction();
-            DB::insert('insert into researches (user_id,start_time) values (?,?)', [$userId, Carbon::now()]);
-
-            $user = DB::select('select * from users where id=?', [$userId]);
-            $research = DB::select('select id from researches where user_id=? order by id desc', [$userId])[0];
-
-            if ($user[0]->is_started) { // 開始時間が打刻されている場合はrollbackしてエラーメッセージを表示させる
-                DB::rollBack();
-                return false;
-            }
-            DB::update('update users set is_started=true,research_id=? where id=?', [$research->id, $userId]);
-            DB::commit();
-            return true;
-        } catch (Throwable $e) {
-            Log::debug($e);
-            DB::rollBack();
-        }
-    }
-
-    /**
-     * 終了時間を登録する
-     *
-     * @param integer $userId
-     * @return boolean
-     */
-    public function updateTime(int $userId)
-    {
-        try {
-            DB::beginTransaction();
-
-            $user = User::find($userId);
-            if (!$user->is_started) {
-                return false;
-            }
-
-            DB::update('update users set is_started=false where users.id=?', [$userId]);
-            $endTime = Carbon::now();
-            DB::update('update researches set end_time=? where id=(select research_id from users where users.id=?)', [$endTime, $userId]);
-
-            $startTime = new Carbon(Db::select('select start_time from researches where id=(select research_id from users where users.id=?)', [$userId])[0]->start_time);
-
-            // 時間の単位を(H)に変換し今週の研究時間に加算
-            $researchTime = $this->timeBasedConversionService->convertTimeToHour($startTime, $endTime);
-
-            //研究時間を登録・更新する処理　1週間に入っているのか新たに更新する必要があるのかどうかの分岐
-            // ここで前回登録していたweeklytimeを取得
-            $weekFirst = Carbon::today()->startOfWeek();
-            $weekLast = Carbon::today()->addWeek(1);
-            $createdWeeklyTime = new Carbon($user?->currentWeeklyTime?->created_at);
-
-            // 前回登録した週間研究時間が先週のものであれば新しく作成し、そうでなければ前回の週間研究時間を取得し、更新する
-            if (is_null($user?->currentWeeklyTime) || ($createdWeeklyTime->lt($weekFirst) || $createdWeeklyTime->gt($weekLast))) {
-                $this->weeklyTimeRepository->store($researchTime);
-            } else {
-                $weeklyTime = $user->currentWeeklyTime;
-                $this->weeklyTimeRepository->update($weeklyTime, $researchTime);
-            }
-
-            DB::commit();
-            return true;
-        } catch (Throwable $e) {
-            Log::debug($e);
-            DB::rollBack();
-        }
     }
 }

--- a/src/app/Models/Rest.php
+++ b/src/app/Models/Rest.php
@@ -2,11 +2,8 @@
 
 namespace App\Models;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
-use Throwable;
 
 class Rest extends Model
 {
@@ -26,51 +23,5 @@ class Rest extends Model
     public function research()
     {
         return $this->belongsTo(Time::class);
-    }
-
-    /**
-     * 開始時間を登録する
-     *
-     * @param integer $researchId
-     * @return boolean
-     */
-    public function storeTime(int $researchId)
-    {
-        try {
-            DB::beginTransaction();
-            $rest = $this->create([
-                'research_id' => $researchId,
-                'start_time' => Carbon::now()
-            ]);
-            $research = Research::find($researchId);
-
-            if ($research->user->is_rested) { // 開始時間が打刻されている場合はrollbackしてエラーメッセージを表示させる
-                DB::rollBack();
-                return false;
-            }
-            $research->user->fill(['is_rested' => true, 'rest_id' => $rest->id])->save();
-            DB::commit();
-            return true;
-        } catch (Throwable $e) {
-            Log::debug($e);
-            DB::rollBack();
-        }
-    }
-
-    /**
-     * 終了時間を登録する
-     *
-     * @param integer $researchId
-     * @return boolean
-     */
-    public function updateTime(int $researchId)
-    {
-        $research = Research::find($researchId);
-        if (!$research->user->is_rested) {
-            return false;
-        }
-        // ここもトランザクション加えたほうがいいかも
-        $research->user->currentRest->fill(['end_time' => Carbon::now()])->save();
-        return $research->user->fill(['is_rested' => false])->save();
     }
 }

--- a/src/app/Models/Rest.php
+++ b/src/app/Models/Rest.php
@@ -52,6 +52,7 @@ class Rest extends Model
             DB::commit();
             return true;
         } catch (Throwable $e) {
+            Log::debug($e);
             DB::rollBack();
         }
     }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -24,6 +24,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'password',
         'research_id',
         'rest_id',
+        'weekly_time_id',
         'is_started',
         'is_rested',
     ];
@@ -53,6 +54,11 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->hasMany(Time::class);
     }
 
+    public function weeklyTime()
+    {
+        return $this->hasOne(weeklyTime::class);
+    }
+
     /**
      * 現在記録中のtimesに紐付ける
      *
@@ -71,5 +77,15 @@ class User extends Authenticatable implements MustVerifyEmail
     public function currentRest()
     {
         return $this->hasOne('App\Models\Rest', 'id', 'rest_id');
+    }
+
+    /**
+     * 今週の週間研究時間を紐付ける
+     *
+     * @return void
+     */
+    public function currentWeeklyTime()
+    {
+        return $this->hasOne('App\Models\WeeklyTime', 'id', 'weekly_time_id');
     }
 }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -66,7 +66,7 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function currentResearch()
     {
-        return $this->hasOne('App\Models\Research', 'id', 'research_id');
+        return $this->hasOne(Research::class, 'id', 'research_id');
     }
 
     /**

--- a/src/app/Models/WeeklyTime.php
+++ b/src/app/Models/WeeklyTime.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class WeeklyTime extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'research_time',
+        'rest_time',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/app/Providers/RepositoryServiceProvider.php
+++ b/src/app/Providers/RepositoryServiceProvider.php
@@ -15,6 +15,18 @@ class RepositoryServiceProvider extends ServiceProvider
             \App\Repositories\TargetTime\TargetTimeRepositoryInterface::class,
             \App\Repositories\TargetTime\TargetTimeRepository::class
         );
+        $this->app->bind(
+            \App\Repositories\WeeklyTime\WeeklyTimeRepositoryInterface::class,
+            \App\Repositories\WeeklyTime\WeeklyTimeRepository::class
+        );
+        $this->app->bind(
+            \App\Repositories\Rest\RestRepositoryInterface::class,
+            \App\Repositories\Rest\RestRepository::class
+        );
+        $this->app->bind(
+            \App\Repositories\Research\ResearchRepositoryInterface::class,
+            \App\Repositories\Research\ResearchRepository::class
+        );
     }
 
     /**

--- a/src/app/Repositories/Research/ResearchRepository.php
+++ b/src/app/Repositories/Research/ResearchRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Repositories\Research;
+
+use App\Models\Research;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ResearchRepository implements ResearchRepositoryInterface
+{
+    private $targetTime;
+    /**
+     * @var App\Models\TargetTime
+     */
+    public function __construct(TargetTime $targetTime)
+    {
+        $this->targetTime = $targetTime;
+    }
+
+    /**
+     * 目標時間を登録する
+     *
+     * @param Request $request
+     * @return TargetTime
+     */
+    public function store(Request $request): Research
+    {
+        $time = $request->input('time');
+
+        $userId = Auth::id();
+        return $this->targetTime->create([
+            'user_id' => $userId,
+            'time' => $time
+        ]);
+    }
+
+    /**
+     * 目標時間を更新する
+     *
+     * @param Request $request
+     * @return \App\Models\TargetTime
+     */
+    public function update(Request $request, int $targetTimeId): void
+    {
+        $time = $request->input('time');
+
+        $this->targetTime::find($targetTimeId)->fill(['time' => $time])->save();;
+    }
+}

--- a/src/app/Repositories/Research/ResearchRepositoryInterface.php
+++ b/src/app/Repositories/Research/ResearchRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Repositories\Research;
+
+use App\Models\Research;
+use Illuminate\Http\Request;
+
+interface ResearchRepositoryInterface
+{
+    public function store(Request $request): Research;
+    public function update(Request $request, int $targetTimeId): void;
+}

--- a/src/app/Repositories/Rest/RestRepository.php
+++ b/src/app/Repositories/Rest/RestRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Repositories\Rest;
+
+use App\Models\Rest;
+use Carbon\Carbon;
+
+class RestRepository implements RestRepositoryInterface
+{
+    private $rest;
+    /**
+     * @var \App\Models\Rest
+     */
+    public function __construct(Rest $rest)
+    {
+        $this->rest = $rest;
+    }
+
+    /**
+     * 休憩時間を登録する
+     *
+     * @param int $researchId
+     * @return Rest
+     */
+    public function store(int $researchId): Rest
+    {
+        return $this->rest->create([
+            'research_id' => $researchId,
+            'start_time' => Carbon::now()
+        ]);
+    }
+
+    /**
+     * 休憩時間を更新する
+     *
+     * @param Rest $request
+     * @return \App\Models\TargetTime
+     */
+    public function update(Rest $currentRest, $endTime): void
+    {
+        $currentRest->fill(['end_time' => $endTime])->save();
+    }
+}

--- a/src/app/Repositories/Rest/RestRepositoryInterface.php
+++ b/src/app/Repositories/Rest/RestRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Repositories\Rest;
+
+use Illuminate\Http\Request;
+use App\Models\Rest;
+
+interface RestRepositoryInterface
+{
+    public function store(int $researchId): Rest;
+    public function update(Rest $currentRest, $endTime): void;
+}

--- a/src/app/Repositories/TargetTime/TargetTimeRepositoryInterface.php
+++ b/src/app/Repositories/TargetTime/TargetTimeRepositoryInterface.php
@@ -8,4 +8,5 @@ use Illuminate\Http\Request;
 interface TargetTimeRepositoryInterface
 {
     public function store(Request $request): TargetTime;
+    public function update(Request $request, int $targetTimeId): void;
 }

--- a/src/app/Repositories/WeeklyTime/WeeklyTimeRepository.php
+++ b/src/app/Repositories/WeeklyTime/WeeklyTimeRepository.php
@@ -22,7 +22,7 @@ class WeeklyTimeRepository implements WeeklyTimeRepositoryInterface
      *
      * @return void
      */
-    public function store($researchTime): void
+    public function storeResearchTime(float $researchTime): void
     {
         $userId = Auth::id();
         $createdweeklyTime = $this->weeklyTime->create([
@@ -34,12 +34,43 @@ class WeeklyTimeRepository implements WeeklyTimeRepositoryInterface
 
     /**
      * 週間研究時間を加算して更新する
-     *
+     * 
+     * @param \App\Models\WeeklyTime $weeklyTime
+     * @param float $researchTime
      * @return bool
      */
-    public function update($weeklyTime, $researchTime): bool
+    public function updateResearchTime(WeeklyTime $weeklyTime, float $researchTime): bool
     {
         $updatedWeeklyTime = $weeklyTime->research_time + $researchTime;
         return $weeklyTime->fill(['research_time' => $updatedWeeklyTime])->save();
+    }
+
+    /**
+     * 週間休憩時間を登録する
+     *
+     * @param float $restTime
+     * @return void
+     */
+    public function storeRestTime(float $restTime): void
+    {
+        $userId = Auth::id();
+        $createdweeklyTime = $this->weeklyTime->create([
+            'user_id' => $userId,
+            'rest_time' => $restTime,
+        ]);
+        User::find($userId)->fill(['weekly_time_id' => $createdweeklyTime->id])->save();
+    }
+
+    /**
+     * 週間休憩時間を加算して更新する
+     * 
+     * @param \App\Models\WeeklyTime $weeklyTime
+     * @param float $researchTime
+     * @return bool
+     */
+    public function updateRestTime(WeeklyTime $weeklyTime, $restTime): bool
+    {
+        $updatedWeeklyTime = $weeklyTime->research_time + $restTime;
+        return $weeklyTime->fill(['rest_time' => $updatedWeeklyTime])->save();
     }
 }

--- a/src/app/Repositories/WeeklyTime/WeeklyTimeRepository.php
+++ b/src/app/Repositories/WeeklyTime/WeeklyTimeRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Repositories\WeeklyTime;
+
+use App\Models\WeeklyTime;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+class WeeklyTimeRepository implements WeeklyTimeRepositoryInterface
+{
+    private $weeklyTime;
+    /**
+     * @var App\Models\WeeklyTime
+     */
+    public function __construct(WeeklyTime $weeklyTime)
+    {
+        $this->weeklyTime = $weeklyTime;
+    }
+
+    /**
+     * 週間研究時間を登録する
+     *
+     * @return void
+     */
+    public function store($researchTime): void
+    {
+        $userId = Auth::id();
+        $createdweeklyTime = $this->weeklyTime->create([
+            'user_id' => $userId,
+            'research_time' => $researchTime,
+        ]);
+        User::find($userId)->fill(['weekly_time_id' => $createdweeklyTime->id])->save();
+    }
+
+    /**
+     * 週間研究時間を加算して更新する
+     *
+     * @return bool
+     */
+    public function update($weeklyTime, $researchTime): bool
+    {
+        $updatedWeeklyTime = $weeklyTime->research_time + $researchTime;
+        return $weeklyTime->fill(['research_time' => $updatedWeeklyTime])->save();
+    }
+}

--- a/src/app/Repositories/WeeklyTime/WeeklyTimeRepositoryInterface.php
+++ b/src/app/Repositories/WeeklyTime/WeeklyTimeRepositoryInterface.php
@@ -2,10 +2,12 @@
 
 namespace App\Repositories\WeeklyTime;
 
-use Illuminate\Http\Request;
+use App\Models\WeeklyTime;
 
 interface WeeklyTimeRepositoryInterface
 {
-    public function store(Request $request): void;
-    public function update($weeklyTime, $researchTime): bool;
+    public function storeResearchTime(float $researchTime): void;
+    public function updateResearchTime(WeeklyTime $weeklyTime, float $researchTime): bool;
+    public function storeRestTime(float $restTime): void;
+    public function updateRestTime(WeeklyTime $weeklyTime, float $restTime): bool;
 }

--- a/src/app/Repositories/WeeklyTime/WeeklyTimeRepositoryInterface.php
+++ b/src/app/Repositories/WeeklyTime/WeeklyTimeRepositoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Repositories\WeeklyTime;
+
+use Illuminate\Http\Request;
+
+interface WeeklyTimeRepositoryInterface
+{
+    public function store(Request $request): void;
+    public function update($weeklyTime, $researchTime): bool;
+}

--- a/src/app/Services/ResearchService.php
+++ b/src/app/Services/ResearchService.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+use App\Models\User;
+use App\Repositories\WeeklyTime\WeeklyTimeRepository;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class ResearchService
+{
+    private $weeklyTimeRepository;
+    private $timeBasedConversionService;
+
+    public function __construct(TimeBasedConversionService $timeBasedConversionService, WeeklyTimeRepository $weeklyTimeRepository)
+    {
+        $this->timeBasedConversionService = $timeBasedConversionService;
+        $this->weeklyTimeRepository = $weeklyTimeRepository;
+    }
+
+    /**
+     * 研究開始時間を登録する
+     *
+     * @param integer $userId
+     * @return boolean
+     */
+    public function store(int $userId)
+    {
+        try {
+            DB::beginTransaction();
+            DB::insert('insert into researches (user_id,start_time) values (?,?)', [$userId, Carbon::now()]);
+
+            $user = DB::select('select * from users where id=?', [$userId]);
+            $research = DB::select('select id from researches where user_id=? order by id desc', [$userId])[0];
+
+            if ($user[0]->is_started) { // 開始時間が打刻されている場合はrollbackしてエラーメッセージを表示させる
+                DB::rollBack();
+                return false;
+            }
+            DB::update('update users set is_started=true,research_id=? where id=?', [$research->id, $userId]);
+            DB::commit();
+            return true;
+        } catch (Throwable $e) {
+            Log::debug($e);
+            DB::rollBack();
+        }
+    }
+
+    /**
+     * 研究終了時間を登録する
+     *
+     * @param integer $userId
+     * @return boolean
+     */
+    public function update(int $userId)
+    {
+        try {
+            DB::beginTransaction();
+
+            $user = User::find($userId);
+            if (!$user->is_started) {
+                return false;
+            }
+
+            DB::update('update users set is_started=false where users.id=?', [$userId]);
+            $endTime = Carbon::now();
+            DB::update('update researches set end_time=? where id=(select research_id from users where users.id=?)', [$endTime, $userId]);
+
+            $startTime = new Carbon(Db::select('select start_time from researches where id=(select research_id from users where users.id=?)', [$userId])[0]->start_time);
+
+            // 時間の単位を(H)に変換し今週の研究時間に加算
+            $researchTime = $this->timeBasedConversionService->convertTimeToHour($startTime, $endTime);
+
+            //研究時間を登録・更新する処理　1週間に入っているのか新たに更新する必要があるのかどうかの分岐
+            $weekFirst = Carbon::today()->startOfWeek();
+            $weekLast = Carbon::today()->addWeek(1);
+            $createdWeeklyTime = new Carbon($user?->currentWeeklyTime?->created_at);
+
+            // 前回登録したweekly_timesがない、もしくは先週のものであれば新しく作成し、そうでなければ前回のweekly_timesのresearch_timeを取得し、更新する
+            if (is_null($user?->currentWeeklyTime) || ($createdWeeklyTime->lt($weekFirst) || $createdWeeklyTime->gt($weekLast))) {
+                $this->weeklyTimeRepository->storeResearchTime($researchTime);
+            } else {
+                /** @var \App\Models\WeeklyTime */
+                $weeklyTime = $user->currentWeeklyTime;
+                $this->weeklyTimeRepository->updateResearchTime($weeklyTime, $researchTime);
+            }
+
+            DB::commit();
+            return true;
+        } catch (Throwable $e) {
+            Log::debug($e);
+            DB::rollBack();
+        }
+    }
+}

--- a/src/app/Services/RestService.php
+++ b/src/app/Services/RestService.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\Rest\RestRepository;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+use Carbon\Carbon;
+use App\Repositories\WeeklyTime\WeeklyTimeRepository;
+use App\Services\TimeBasedConversionService;
+use App\Models\Research;
+use Illuminate\Support\Facades\Auth;
+
+class RestService
+{
+    private $timeBasedConversionService;
+    private $weeklyTimeRepository;
+    private $restRepository;
+
+    public function __construct(TimeBasedConversionService $timeBasedConversionService, WeeklyTimeRepository $weeklyTimeRepository, RestRepository $restRepository)
+    {
+        $this->timeBasedConversionService = $timeBasedConversionService;
+        $this->weeklyTimeRepository = $weeklyTimeRepository;
+        $this->restRepository = $restRepository;
+    }
+
+    /**
+     * 休憩開始時間を登録する
+     *
+     * @param integer $researchId
+     * @return boolean
+     */
+    public function store(int $researchId)
+    {
+        try {
+            DB::beginTransaction();
+            $rest = $this->restRepository->store($researchId);
+
+            $user = User::find(Auth::id());
+
+            if ($user->is_rested) { // 開始時間が打刻されている場合はrollbackしてエラーメッセージを表示させる
+                DB::rollBack();
+                return false;
+            }
+            // ここもrepositoryで切り分け
+            $user->fill(['is_rested' => true, 'rest_id' => $rest->id])->save();
+            DB::commit();
+            return true;
+        } catch (Throwable $e) {
+            Log::debug($e);
+            DB::rollBack();
+        }
+    }
+
+    /**
+     * 休憩終了時間を登録する
+     *
+     * @param integer $researchId
+     * @return boolean
+     */
+    public function update(int $researchId)
+    {
+        try {
+            $user = User::find(Auth::id());
+            $research = Research::find($researchId);
+            if (!$research->user->is_rested) {
+                return false;
+            }
+
+            $currentRest = $research->user->currentRest;
+            // 休憩開始・終了時間
+            $startTime = $currentRest->start_time;
+            $endTime = Carbon::now();
+
+            $this->restRepository->update($currentRest, $endTime);
+            // $research->user->currentRest->fill(['end_time' => $endTime])->save();
+            // あとで切り分け対応
+            $research->user->fill(['is_rested' => false])->save();
+
+            // 時間の単位を(H)に変換し、今週の休憩時間に加算
+            $restTime = $this->timeBasedConversionService->convertTimeToHour($startTime, $endTime);
+
+            // 今週の初めと終わりの日を取得
+            $weekFirst = Carbon::today()->startOfWeek();
+            $weekLast = Carbon::today()->addWeek(1);
+            $createdWeeklyTime = new Carbon($user?->currentWeeklyTime?->created_at);
+
+            // 前回登録したweekly_timesがない、もしくは先週のものであれば新しく作成し、そうでなければ前回のweekly_timesのrest_timeを取得し、更新する
+            if (is_null($user?->currentWeeklyTime) || ($createdWeeklyTime->lt($weekFirst) || $createdWeeklyTime->gt($weekLast))) {
+                $this->weeklyTimeRepository->storeRestTime($restTime);
+            } else {
+                $weeklyTime = $user->currentWeeklyTime;
+                $this->weeklyTimeRepository->updateRestTime($weeklyTime, $restTime);
+            }
+
+            DB::commit();
+
+            return true;
+        } catch (Throwable $e) {
+            Log::debug($e);
+            DB::rollBack();
+        }
+    }
+}

--- a/src/app/Services/TimeBasedConversionService.php
+++ b/src/app/Services/TimeBasedConversionService.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Services;
+
+
+class TimeBasedConversionService
+{
+    public function convertTimeToHour($startTime, $endTime)
+    {
+        $diffSeconds = $endTime->diffInSeconds($startTime);
+        return round($diffSeconds / 3600, 2);
+    }
+}

--- a/src/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/database/migrations/2014_10_12_000000_create_users_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->string('password');
             $table->integer('research_id')->nullable();
             $table->integer('rest_id')->nullable();
+            $table->integer('weekly_time_id')->nullable();
             $table->rememberToken();
             $table->timestamps();
         });

--- a/src/database/migrations/2023_05_26_150209_create_weekly_times_table.php
+++ b/src/database/migrations/2023_05_26_150209_create_weekly_times_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('weekly_times', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->float('research_time')->nullable();
+            $table->float('rest_time')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('weekly_times');
+    }
+};

--- a/src/resources/js/Pages/Dashboard.tsx
+++ b/src/resources/js/Pages/Dashboard.tsx
@@ -6,18 +6,19 @@ import TimeManagement from './TimeManagement/TimeManagement';
 
 type DashboardPropsType = {
   targetTime: any;
+  weeklyTime: number;
 };
 
 export default function Dashboard(
   // pageprops: PageProps,
-  { targetTime }: DashboardPropsType
+  { targetTime, weeklyTime }: DashboardPropsType
 ) {
   // const { auth } = pageprops;
   return (
     <>
       {/* <AuthenticatedLayout user={auth.user}> */}
       <Head title="Dashboard" />
-      <TimeManagement targetTime={targetTime} />
+      <TimeManagement targetTime={targetTime} weeklyTime={weeklyTime} />
       {/* </AuthenticatedLayout> */}
     </>
   );

--- a/src/resources/js/Pages/TimeManagement/TargetTimeList.tsx
+++ b/src/resources/js/Pages/TimeManagement/TargetTimeList.tsx
@@ -7,7 +7,7 @@ import type {
   TargetTimeEditProps
 } from '@/types/TimeManagement/TimeManagementType';
 
-function TargetTimeList({ targetTime }: TargetTimeEditProps) {
+function TargetTimeList({ targetTime, weeklyTime }: TargetTimeEditProps) {
   const { control, handleSubmit } = useForm<TargetTimeInputs>();
   const onTargetTimeSubmit: SubmitHandler<TargetTimeInputs> = (
     data: TargetTimeInputs
@@ -20,9 +20,16 @@ function TargetTimeList({ targetTime }: TargetTimeEditProps) {
       <div className="max-w-7xl w-2/3 mx-auto mt-10 sm:px-6 lg:px-8 flex justify-evenly items-center">
         {targetTime !== null && (
           <>
-            <p>{`今週の目標時間   ${targetTime?.time}時間`}</p>
-            <div>
-              <p>目標時間達成まであと　時間</p>
+            <div className="text-center">
+              <p>今週の目標時間</p>
+              <h1 className="font-bold text-2xl">{`${targetTime?.time}時間`}</h1>
+            </div>
+
+            <div className="text-center">
+              <p>目標達成まであと</p>
+              <h1 className="font-bold text-2xl">
+                {`${targetTime.time - weeklyTime}時間`}
+              </h1>
             </div>
           </>
         )}
@@ -49,7 +56,7 @@ function TargetTimeList({ targetTime }: TargetTimeEditProps) {
             </div>
           </div>
         ) : (
-          <div className="ml-3">
+          <div>
             <Button
               variant="contained"
               onClick={() =>

--- a/src/resources/js/Pages/TimeManagement/TargetTimeList.tsx
+++ b/src/resources/js/Pages/TimeManagement/TargetTimeList.tsx
@@ -26,10 +26,18 @@ function TargetTimeList({ targetTime, weeklyTime }: TargetTimeEditProps) {
             </div>
 
             <div className="text-center">
-              <p>目標達成まであと</p>
-              <h1 className="font-bold text-2xl">
-                {`${targetTime.time - weeklyTime}時間`}
-              </h1>
+              {targetTime.time < weeklyTime ? (
+                <h1 className="font-bold text-2xl text-red-500">
+                  目標達成！おめでとう！
+                </h1>
+              ) : (
+                <>
+                  <p>目標達成まであと</p>
+                  <h1 className="font-bold text-2xl">
+                    {`${targetTime.time - weeklyTime}時間`}
+                  </h1>
+                </>
+              )}
             </div>
           </>
         )}

--- a/src/resources/js/Pages/TimeManagement/TimeManagement.tsx
+++ b/src/resources/js/Pages/TimeManagement/TimeManagement.tsx
@@ -8,7 +8,7 @@ import useMultipleClickPreventer from '@/Hooks/useMultipleClickPreventer';
 import { TimeManagementProps } from '@/types/TimeManagement/TimeManagementType';
 import TargetTimeList from './TargetTimeList';
 
-function TimeManagement({ targetTime }: TimeManagementProps) {
+function TimeManagement({ targetTime, weeklyTime }: TimeManagementProps) {
   const [open, setOpen] = useState<boolean>(false);
 
   useEffect(() => {
@@ -75,7 +75,7 @@ function TimeManagement({ targetTime }: TimeManagementProps) {
             </div>
           </div>
 
-          <TargetTimeList targetTime={targetTime} />
+          <TargetTimeList targetTime={targetTime} weeklyTime={weeklyTime} />
         </div>
       </div>
     </div>

--- a/src/resources/js/types/TimeManagement/TimeManagementType.ts
+++ b/src/resources/js/types/TimeManagement/TimeManagementType.ts
@@ -6,6 +6,7 @@ type TargetTimeType = {
     created_at: Date;
     updated_at: Date;
   };
+  weeklyTime: number;
 };
 export type TimeManagementProps = TargetTimeType;
 


### PR DESCRIPTION
## Issue
#8 
## ToDo

- `Repository`や`Service`を用いてビジネスロジックやデータの永続化に関する処理を分離
- 週間研究・休憩時間の合計をそれぞれのデータの登録や更新の都度、`weekly_times`テーブルで登録
- 今週の研究時間目標と現在の研究時間の差分を表示

## スクショ
<img width="636" alt="image" src="https://github.com/Rihitonnnu/RTMS/assets/69156872/5f2a7e48-32c8-4fe5-8db6-61c0b994f609">
