### PR TITLE
outlineを表示しないよう修正

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  #outlined-number {
+    @apply border-transparent focus:border-transparent focus:ring-0;
+  }
+}


### PR DESCRIPTION
## Issue
#30 
## ToDo

- `MUI`のinputタグにoutlineが表示されないようにCSSを直接編集して修正

## スクショ
<img width="170" alt="image" src="https://github.com/Rihitonnnu/RTMS/assets/69156872/0c3afa57-6ed7-4ebb-88e8-6de8f5405d5d">
